### PR TITLE
Fixes issue #8

### DIFF
--- a/tinkerpop2/pom.xml
+++ b/tinkerpop2/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>neo4j-gremlin-plugin-tp2</artifactId>
 
     <properties>
-        <tinkerpop-version>2.6.0</tinkerpop-version>
+        <tinkerpop-version>2.7.0-SNAPSHOT</tinkerpop-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Bumping up tinkerpop to version `2.7.0-SNAPSHOT` which supports Neo4j 2.2.1
